### PR TITLE
Blacklist support Jekyll front matter #92

### DIFF
--- a/plugin/pencil.vim
+++ b/plugin/pencil.vim
@@ -78,9 +78,10 @@ if !exists('g:pencil#autoformat_config')
         \     'black': [
         \       'htmlH[0-9]',
         \       'markdown(Code|H[0-9]|Url|IdDeclaration|Link|Rule|Highlight[A-Za-z0-9]+)',
-        \       'markdown(FencedCodeBlock|InlineCode)',
+        \       'markdown(FencedCodeBlock|InlineCode|YamlHead)',
         \       'mkd(Code|Rule|Delimiter|Link|ListItem|IndentCode|Snippet)',
         \       'mmdTable[A-Za-z0-9]*',
+        \       '^yaml*',
         \     ],
         \     'white': [
         \      'markdown(Code|Link)',


### PR DESCRIPTION
Closes #92

Tested with default markdown syntax.

Note: the "^yaml*" highlight group prefix that I added to the blacklist for markdown may be superfluous. It seems to function as a secondary highlight group. Its presence shouldn't have a performance hit.

@reedes